### PR TITLE
version bump to node 8.16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8.9-alpine
+FROM node:8.16-alpine
 
 LABEL maintainer "Carimus <connect@carimus.com>"
 


### PR DESCRIPTION
**Changes**
* only change here is version bumping to use node:8.16-alpine base image

**Note**: pushed to docker hub and tagged under carimus/php-node-builder:php71v3